### PR TITLE
Remove require call in in favour of import statment

### DIFF
--- a/src/StructuredText/index.ts
+++ b/src/StructuredText/index.ts
@@ -1,4 +1,4 @@
-import { defineComponent, PropType, VNodeProps, VNode, isVue3 } from 'vue-demi';
+import { defineComponent, PropType, VNodeProps, VNode, isVue3, cloneVNode, isVNode } from 'vue-demi';
 import {
   render,
   renderRule,
@@ -61,8 +61,6 @@ export function appendKeyToValidElement(
   key: string,
 ): AdapterReturn {
   if (isVue3) {
-    const { isVNode, cloneVNode } = require('vue');
-
     if (isVNode(element) && (element as VNode).key === null) {
       return cloneVNode(element, { key });
     }


### PR DESCRIPTION
In `StructuredText/index.ts` `vue` was required via `require('vue')` during
the execution of `appendKeyToValidElement`.

When this component is build via Vite, the require call is not get resolved and throws an error in the production build.

The `vue-demi` package (which is `import`ed already) does export the
`isVNode` and `cloneVNode` functions (which is the reason vue was
required). The `vue-demi` versions are used now