### PR TITLE
docs: replace instance of 'react' in `useSiteSearch` README

### DIFF
--- a/src/composables/useSiteSearch/README.md
+++ b/src/composables/useSiteSearch/README.md
@@ -24,7 +24,7 @@ npm install --save vue-datocms @datocms/cma-client-browser
 Import `useSiteSearch` from `vue-datocms` and use it inside your components like this:
 
 ```js
-import { useSiteSearch } from 'react-datocms';
+import { useSiteSearch } from 'vue-datocms';
 import { buildClient } from '@datocms/cma-client-browser';
 
 const client = buildClient({ apiToken: 'YOUR_API_TOKEN' });


### PR DESCRIPTION
There was what looks like a copy/paste error from the `react-datocms` version of the `useSiteSearch` README, where the react dependency had been mentioned. This PR replaces it with the vue dependency instead in the code example.