### PR TITLE
Added readme section on video analytics with Mux Data (Vue)

### DIFF
--- a/src/components/VideoPlayer/README.md
+++ b/src/components/VideoPlayer/README.md
@@ -32,6 +32,7 @@ is our recommended way to serve optimal videos to your users.
   - [Setup](#setup)
 - [Usage](#usage)
 - [Props](#props)
+- [Opt-in Viewer Analytics](#opt-in-viewer-analytics)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -160,3 +161,11 @@ inner `<mux-player />`.
   `style` attribute
 
 All the other props are forwarded to the `<mux-player />` web component that is used internally.
+
+## Opt-in Viewer Analytics
+
+This `<VideoPlayer/>` component can OPTIONALLY collect clientside [playback and engagement metrics](https://www.mux.com/data#TechSpecs) such as playback percentages, user agents, and geography.
+
+These analytics are **disabled** by default. To enable them, you must opt in to [Mux Data](https://www.mux.com/data) integration by creating a Mux Data account (free) and providing its `envKey` to the component.
+
+For details and setup instructions, please see our documentation on **[Streaming Video Analytics with Mux Data](https://www.datocms.com/docs/streaming-videos/streaming-video-analytics-with-mux-data)**.


### PR DESCRIPTION
Added brief description and link to our [Mux Data docs](https://www.datocms.com/docs/streaming-videos/streaming-video-analytics-with-mux-data):

<img width="1659" height="352" alt="react-datocmsdocsvideo-player md at e07ca6f229870d84162bb3331555da38f27625d8 · datocmsreact-datocms - 2025-09-26 01-00-28 PM" src="https://github.com/user-attachments/assets/c08cbf71-d791-4a80-85f0-e764d46ccb5f" />

This same change was made in three readmes:

- React: https://github.com/datocms/react-datocms/pull/114
- Svelte: https://github.com/datocms/datocms-svelte/pull/16
- Vue (this PR): https://github.com/datocms/vue-datocms/pull/107
