### PR TITLE
VideoPlayer: default poster to `data.thumbnailUrl`

### DIFF
--- a/src/components/VideoPlayer/__tests__/index.test.ts
+++ b/src/components/VideoPlayer/__tests__/index.test.ts
@@ -31,4 +31,34 @@ describe('VideoPlayer', () => {
       expect(wrapper.html()).toMatchSnapshot();
     });
   });
+
+  describe('with data.thumbnailUrl', () => {
+    const data = {
+      muxPlaybackId: 'ip028MAXF026dU900bKiyNDttjonw7A1dFY',
+      title: 'Title',
+      width: 1080,
+      height: 1920,
+      thumbnailUrl: 'https://example.com/thumb.jpg',
+    };
+
+    it('uses the thumbnail as poster', () => {
+      const wrapper = mount(VideoPlayer, {
+        propsData: { data },
+      } as any);
+
+      expect(wrapper.get('mux-player').attributes('poster')).toBe(
+        'https://example.com/thumb.jpg',
+      );
+    });
+
+    it('lets an explicitly passed poster win over the thumbnail', () => {
+      const wrapper = mount(VideoPlayer, {
+        propsData: { data, poster: 'https://example.com/custom.jpg' },
+      } as any);
+
+      expect(wrapper.get('mux-player').attributes('poster')).toBe(
+        'https://example.com/custom.jpg',
+      );
+    });
+  });
 });

--- a/src/components/VideoPlayer/index.ts
+++ b/src/components/VideoPlayer/index.ts
@@ -36,6 +36,8 @@ export type Video = {
   playbackId?: Possibly<string>;
   /** A data: URI containing a blurhash for the video  */
   blurUpThumb?: Possibly<string>;
+  /** A URL for the video thumbnail, used as the poster image */
+  thumbnailUrl?: Possibly<string>;
   /** Other data can be passed, but they have no effect on rendering the player */
   // biome-ignore lint/suspicious/noExplicitAny: we intentionally want to allow to add any other value to this video object
   [k: string]: any;

--- a/src/composables/useVideoPlayer/index.ts
+++ b/src/composables/useVideoPlayer/index.ts
@@ -31,16 +31,22 @@ const computedPlaceholder = (blurUpThumb: Possibly<string>) => {
   return blurUpThumb ? { placeholder: blurUpThumb } : undefined;
 };
 
+const computedPoster = (thumbnailUrl: Possibly<string>) => {
+  return thumbnailUrl ? { poster: thumbnailUrl } : undefined;
+};
+
 type Style = Maybe<CSSProperties>;
 type Title = Maybe<string>;
 type PlaybackId = Maybe<string>;
 type Placeholder = Maybe<string>;
+type Poster = Maybe<string>;
 
 type AttrsForMuxPlayer = {
   style?: Style;
   title?: Title;
   playbackId?: PlaybackId;
   placeholder?: Placeholder;
+  poster?: Poster;
 };
 
 type UseVideoPlayerArgs = {
@@ -50,8 +56,15 @@ type UseVideoPlayerArgs = {
 export const useVideoPlayer = ({
   data,
 }: UseVideoPlayerArgs): AttrsForMuxPlayer => {
-  const { title, width, height, playbackId, muxPlaybackId, blurUpThumb } =
-    data || {};
+  const {
+    title,
+    width,
+    height,
+    playbackId,
+    muxPlaybackId,
+    blurUpThumb,
+    thumbnailUrl,
+  } = data || {};
 
   if (data === undefined) return {};
 
@@ -60,5 +73,6 @@ export const useVideoPlayer = ({
     ...(computedPlaybackId(muxPlaybackId, playbackId) || {}),
     ...(computedStyle(width, height) || {}),
     ...(computedPlaceholder(blurUpThumb) || {}),
+    ...(computedPoster(thumbnailUrl) || {}),
   };
 };


### PR DESCRIPTION
Pass `data.thumbnailUrl` as the poster prop to the Mux player when present. A consumer-supplied poster still takes precedence, since computed props are spread before the rest props on the mux-player element.